### PR TITLE
Bugfixes, improvements, better support for Virtuoso and Blazegraph

### DIFF
--- a/snorql/index.html
+++ b/snorql/index.html
@@ -43,16 +43,24 @@
     </div>
 
     <div class="section" style="margin-right: 12em">
-      <h2>SPARQL:</h2>
-      <pre id="prefixestext"></pre>
+      <h2>SPARQL: <input type="button" id="prefixes_button" value="Show Prefixes" onClick="showHidePrefixes();"/></h2>
+      <code id="prefixestext" class="prefixes" style="display:none;"></code>
       <form id="queryform" action="#" method="get"><div>
         <input type="hidden" name="query" value="" id="query" />
+        <input type="hidden" name="update" value="" id="update" disabled="disabled"/>
+        <input type="hidden" name="sendas" value="query" id="sendas" />
         <input type="hidden" name="output" value="json" id="jsonoutput" disabled="disabled" />
+        <input type="hidden" name="format" value="json" id="format" disabled="disabled" />
         <input type="hidden" name="stylesheet" value="" id="stylesheet" disabled="disabled" />
         <input type="hidden" name="graph" value="" id="graph-uri" disabled="disabled" />
       </div></form>
       <div>
         <textarea name="query" rows="9" cols="80" id="querytext"></textarea>
+        Send as:
+        <select id="selectsendas" onchange="snorql.updateOutputMode()">
+          <option selected="selected" value="query">Query</option>
+          <option value="update">Update</option>
+        </select>
         Results:
         <select id="selectoutput" onchange="snorql.updateOutputMode()">
           <option selected="selected" value="browse">Browse</option>

--- a/snorql/style.css
+++ b/snorql/style.css
@@ -8,6 +8,7 @@ h2 { font-weight: normal; font-size: 120%; margin: 0; padding: 0 0 0.2em 0; }
 form { margin: 0; }
 textarea { width: 100%; }
 #prefixestext { color: #555; margin: 0; }
+.prefixes { white-space: pre-line; }
 ul { margin: 0; padding: 0; }
 li { margin: 0 0 0 1em; padding: 0; }
 img { border: none; }


### PR DESCRIPTION
- Fixed encoding problem - now safe to use with russian and other Unicode characters in the query text
- Fixed issue with ASK queries with Virtuoso (they always returned TRUE).
- Added "Send As" dropdown to choose between "query" and "update" parameters. According to SPARQL1.1 specification update queries MUST be send using "update" parameter (not "query" parameter) and Blazegraph does not support update queries in the query parameter (though Virtuoso do support that).
- Added support for non-standard responses (i.e not xml). SPARQL1.1 specification does not regulate response format for update queries. While Virtuoso uses standard SPARQL-XML responses, Blazegraph provides plain html message. In case response is not parsable it is displayed as a whole as plain html.
- Prefixes are displayed one in a row and by default are hidden. Can be shown using [Show Prefixes] button.
- Added support for in-query prefixes - duplicated prefixes are automatically removed, in-query prefixes are applied to result grid the same way as default prefixes.
- "Results as XML" did not really work for Virtuoso - added parameter "format=xml"
